### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/aiw-devops/4b5d060c-a869-4013-aed8-ba8c5a51c2d2/a5640ab8-c268-4171-8651-02d638ed71f0/_apis/work/boardbadge/121a8fd2-132d-4649-9a3c-d06d0315dc5f)](https://dev.azure.com/aiw-devops/4b5d060c-a869-4013-aed8-ba8c5a51c2d2/_boards/board/t/a5640ab8-c268-4171-8651-02d638ed71f0/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#445](https://dev.azure.com/aiw-devops/4b5d060c-a869-4013-aed8-ba8c5a51c2d2/_workitems/edit/445). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.